### PR TITLE
Adding support for CT30 (v1.92)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,7 @@ Device Versions
 
 Supported models:
 
+- CT30 v1.92
 - CT50 V1.09
 - CT50 V1.88
 - CT50 V1.94

--- a/radiotherm/__init__.py
+++ b/radiotherm/__init__.py
@@ -1,8 +1,8 @@
-from .thermostat import Thermostat, CommonThermostat, CT50v109, CT50v188, CT50v194, CT80RevB2v103
+from .thermostat import Thermostat, CommonThermostat, CT30v192, CT50v109, CT50v188, CT50v194, CT80RevB2v103
 from . import discover
 from . import fields
 
-THERMOSTATS = (CT50v109, CT50v188, CT50v194, CT80RevB2v103,)
+THERMOSTATS = (CT30v192, CT50v109, CT50v188, CT50v194, CT80RevB2v103,) 
 
 def get_thermostat_class(model):
     """

--- a/radiotherm/thermostat.py
+++ b/radiotherm/thermostat.py
@@ -229,6 +229,14 @@ class CT80RevB(CT80):
 
 
 # Specific model classes
+class CT30v192(CT30):
+    """
+    Defines API features that differ for this specific model from
+    CommonThermostat
+    """
+    MODEL = 'CT30 V1.92'
+
+
 class CT50v109(CT30):
     """
     Defines API features that differ for this specific model from


### PR DESCRIPTION
Just added a new subclass for the model of thermostat I happen to have.  

Everything seems to work, with the exception of `tstat.night_light`.  A request to `/tstat/night_light` comes back with `{"intensity": -1}` which fails to map to a human readable value.