### PR TITLE
Add support for CT80 RevB2 V1.09

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,7 @@ Supported models:
 - CT50 V1.88
 - CT50 V1.94
 - CT80 Rev B2 V1.03
+- CT80 Rev B2 V1.09
 
 Since I only have access to the 3M50 (which reports its model as "CT50 V1.94"),
 that is the model that most development has occured with. Do you have another

--- a/radiotherm/__init__.py
+++ b/radiotherm/__init__.py
@@ -1,8 +1,8 @@
-from .thermostat import Thermostat, CommonThermostat, CT30v192, CT50v109, CT50v188, CT50v194, CT80RevB2v103
+from .thermostat import Thermostat, CommonThermostat, CT30v192, CT50v109, CT50v188, CT50v194, CT80RevB2v103, CT80RevB2v109
 from . import discover
 from . import fields
 
-THERMOSTATS = (CT30v192, CT50v109, CT50v188, CT50v194, CT80RevB2v103,) 
+THERMOSTATS = (CT30v192, CT50v109, CT50v188, CT50v194, CT80RevB2v103, CT80RevB2v109,) 
 
 def get_thermostat_class(model):
     """

--- a/radiotherm/thermostat.py
+++ b/radiotherm/thermostat.py
@@ -263,3 +263,8 @@ class CT50v194(CT30):
 
 class CT80RevB2v103(CT80RevB):
     MODEL = 'CT80 Rev B2 V1.03'
+
+class CT80RevB2v109(CT80RevB):
+    MODEL = 'CT80 Rev B2 V1.09'
+
+


### PR DESCRIPTION
This adds support for the Radio thermostat model CT 80 Rev B2 v1.09.  This thermostat is a Radio thermostat CT80 rebadged at a Current Innovations CT 80