### PR TITLE
Added CT30 v1.99 as a supported model

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,7 @@ Device Versions
 Supported models:
 
 - CT30 v1.92
+- CT30 v1.99
 - CT50 V1.09
 - CT50 V1.88
 - CT50 V1.94

--- a/radiotherm/__init__.py
+++ b/radiotherm/__init__.py
@@ -1,8 +1,8 @@
-from .thermostat import Thermostat, CommonThermostat, CT30v192, CT50v109, CT50v188, CT50v194, CT80RevB2v103
+from .thermostat import Thermostat, CommonThermostat, CT30v192, CT30v199, CT50v109, CT50v188, CT50v194, CT80RevB2v103
 from . import discover
 from . import fields
 
-THERMOSTATS = (CT30v192, CT50v109, CT50v188, CT50v194, CT80RevB2v103,) 
+THERMOSTATS = (CT30v192, CT30v199, CT50v109, CT50v188, CT50v194, CT80RevB2v103,)
 
 def get_thermostat_class(model):
     """

--- a/radiotherm/thermostat.py
+++ b/radiotherm/thermostat.py
@@ -237,6 +237,14 @@ class CT30v192(CT30):
     MODEL = 'CT30 V1.92'
 
 
+class CT30v199(CT30):
+    """
+    Defines API features that differ for this specific model from
+    CommonThermostat
+    """
+    MODEL = 'CT30 V1.99'
+
+
 class CT50v109(CT30):
     """
     Defines API features that differ for this specific model from


### PR DESCRIPTION
Added CT30v1.99 to the list of supported thermostat models. Was having the same problem in home-assistant as referenced in #18 
