### PR TITLE
Handle transient errors

### DIFF
--- a/radiotherm/thermostat.py
+++ b/radiotherm/thermostat.py
@@ -65,7 +65,7 @@ class CommonThermostat(Thermostat):
         validate.validate_response(response)
 
     ### tstat subsystem ###
-    tstat = fields.ReadOnlyField('/tstat', None)
+    tstat = fields.ReadOnlyField('/tstat', None, validate_response=validate.validate_tstat_response)
     model = fields.ReadOnlyField('/tstat/model', 'model')
     version = fields.Field('/tstat/version', 'version')
     temp = fields.ReadOnlyField('/tstat', 'temp')

--- a/radiotherm/validate.py
+++ b/radiotherm/validate.py
@@ -1,5 +1,8 @@
 import json
 
+class RadiothermTstatError(Exception):
+    pass
+
 def validate_response(response, content=None):
     """
     raises AttributeError if the HTTP response code is not 200, or if the value
@@ -11,7 +14,7 @@ def validate_response(response, content=None):
                         This is required if the response was "read" prior to
                         calling this method.
     :type content:      any iterable collection 
-    :returns:           None
+    :returns:           tuple of the validated response and content
     :raises:            AttributeError
     """
     if response.getcode() != 200:
@@ -23,3 +26,30 @@ def validate_response(response, content=None):
     for error_field in ('error_msg', 'error'):
         if error_field in content:
             raise AttributeError('Error message from thermostat: %s' % content[error_field])
+    return response, content
+
+
+def validate_tstat_response(response, content=None):
+    """
+    raises RadiothermTstatError if the HTTP response code is not 200, or if
+    the value returned by the server for /tstat indicates an error.
+
+    :param response:    the response returned by a call to urllib.request.urlopen
+    :type response:     file-like object
+    :param content:     the JSON-deserialized value returned by the server.
+                        This is required if the response was "read" prior to
+                        calling this method.
+    :type content:      any iterable collection
+    :returns:           tuple of the validated response and content
+    :raises:            RadiothermTstatError
+    """
+    response, content = validate_response(response, content)
+    for field in ('temp', 'tmode', 'fmode', 'override', 'hold', 't_heat',
+                  't_cool', 'it_heat', 'lt_cool', 'a_heat', 'a_cool',
+                  'a_mode', 't_type_post', 'tstate', 'fstate', 'time',
+                  'program_mode', 'ttarget'):
+        if field not in content.keys():
+            continue
+        if content[field] == -1:
+            raise RadiothermTstatError()
+    return response, content

--- a/tests/validate/test_validate_response.py
+++ b/tests/validate/test_validate_response.py
@@ -6,6 +6,8 @@ from radiotherm.validate import validate_response
 from tests.base_test_case import BaseTestCase
 
 class TestValidateResponse(BaseTestCase):
+    VALIDATE_RESPONSE = staticmethod(validate_response)
+    SIMPLE_RETURN_VALUE = {}
     COMPLEX_RETURN_VALUE = {
         'foo' : [1, 2, 3],
         'bar' : {'a' : 1, 'b' : 2}
@@ -23,30 +25,31 @@ class TestValidateResponse(BaseTestCase):
 
     def test_200(self):
         response = self.build_mock_response(200)
-        validate_response(response, {})
+        self.VALIDATE_RESPONSE(response, self.SIMPLE_RETURN_VALUE)
 
     def test_404(self):
         response = self.build_mock_response(404)
-        self.assertRaises(AttributeError, validate_response, response, {})
+        self.assertRaises(AttributeError, self.VALIDATE_RESPONSE, response,
+                          self.SIMPLE_RETURN_VALUE)
 
     def test_json_success(self):
         response = self.build_mock_response(200, self.COMPLEX_RETURN_VALUE)
-        validate_response(response)
+        self.VALIDATE_RESPONSE(response)
 
     def test_json_error(self):
         response = self.build_mock_response(200, self.ERROR_RETURN_VALUE)
-        self.assertRaises(AttributeError, validate_response, response)
+        self.assertRaises(AttributeError, self.VALIDATE_RESPONSE, response)
 
     def test_json_error_msg(self):
         response = self.build_mock_response(200, self.ERROR_MSG_RETURN_VALUE)
-        self.assertRaises(AttributeError, validate_response, response)
+        self.assertRaises(AttributeError, self.VALIDATE_RESPONSE, response)
 
     def test_content_error(self):
         response = self.build_mock_response(200)
-        self.assertRaises(AttributeError, validate_response, response,
+        self.assertRaises(AttributeError, self.VALIDATE_RESPONSE, response,
             self.ERROR_RETURN_VALUE)
 
     def test_content_error_msg(self):
         response = self.build_mock_response(200)
-        self.assertRaises(AttributeError, validate_response, response,
+        self.assertRaises(AttributeError, self.VALIDATE_RESPONSE, response,
             self.ERROR_MSG_RETURN_VALUE)

--- a/tests/validate/test_validate_tstat_response.py
+++ b/tests/validate/test_validate_tstat_response.py
@@ -1,0 +1,30 @@
+import json
+
+from mock import MagicMock
+
+from radiotherm.validate import validate_tstat_response, RadiothermTstatError
+from tests.validate.test_validate_response import TestValidateResponse
+
+
+class TestValidateTStatResponse(TestValidateResponse):
+    VALIDATE_RESPONSE = staticmethod(validate_tstat_response)
+    SIMPLE_RETURN_VALUE = {"tmode": 1, "fmode": 2, "temp": 78, "hold": 1}
+    COMPLEX_RETURN_VALUE = SIMPLE_RETURN_VALUE
+    TRANSIENT_ERROR_RETURN_VALUE = {
+        "tmode": -1,
+        "fmode": 2,
+        "temp": -1,
+        "hold": 1
+    }
+
+    def test_json_transient_error(self):
+        response = self.build_mock_response(200,
+                                            self.TRANSIENT_ERROR_RETURN_VALUE)
+        self.assertRaises(RadiothermTstatError, self.VALIDATE_RESPONSE,
+                          response)
+
+    def test_content_transient_error(self):
+        response = self.build_mock_response(200)
+        self.assertRaises(RadiothermTstatError, self.VALIDATE_RESPONSE,
+                          response,
+                          self.TRANSIENT_ERROR_RETURN_VALUE)


### PR DESCRIPTION
The API developer guide in section 2.7.3 states that tmode and/or temp could return a -1 in the case of a transient error within the thermostat. Today these values get returned as-is. We should instead handle these by raising an exception.  This addresses issue #24.