### PR TITLE
Added support to CT80 for setting humidity setpoint

### DIFF
--- a/radiotherm/thermostat.py
+++ b/radiotherm/thermostat.py
@@ -198,6 +198,8 @@ class CT80(CommonThermostat):
             1: 'Run only with heat',
             2: 'Run any time (runs fan)',
         })
+    
+    humidifier_setpoint = fields.Field('/tstat/thumidity', 'thumidity')
 
 
 class CT80RevB(CT80):


### PR DESCRIPTION
From section 2.2.17: Thermostat Humidifier Setpoint in RTCOAWiFIAPIV1_3.pdf

I want this so I can write a dynamic script that changes the humidifier setpoint based on the external temperature.