### PR TITLE
Add optional timeout parameter

### DIFF
--- a/radiotherm/thermostat.py
+++ b/radiotherm/thermostat.py
@@ -22,8 +22,9 @@ class Thermostat(object):
     # and it's the right thing to do.
     JSON_HEADER = {'Content-Type' : 'application/json'}
 
-    def __init__(self, host):
+    def __init__(self, host, timeout=4):
         self.host = host
+        self.timeout = timeout
 
     def get(self, relative_url):
         """
@@ -32,7 +33,7 @@ class Thermostat(object):
         :returns:   file-like object as returned by urllib[2,.request].urlopen
         """
         url = self._construct_url(relative_url)
-        return request.urlopen(url)
+        return request.urlopen(url, timeout=self.timeout)
 
     def post(self, relative_url, value):
         """
@@ -43,7 +44,7 @@ class Thermostat(object):
         """
         url = self._construct_url(relative_url)
         request_instance = request.Request(url, value, self.JSON_HEADER)
-        return request.urlopen(request_instance)
+        return request.urlopen(request_instance, timeout=self.timeout)
 
     def _construct_url(self, relative_url):
         """


### PR DESCRIPTION
This is a perquisite to fixing an issue in the [radiotherm component of HASS](https://github.com/home-assistant/core/issues/25701)

The problem is, the radiotherms have pretty unreliable networking. Resulting in timeouts in about 1% of requests. By default though, the urllib has a really long timeout, which results in the HASS component crapping itself. So we need a way to override the default tiemout, which requires this fix.

For some further context, I did some timing tests against my CT50, and saw the following: 
```
Count:    17121
Min:      2.238989
Max:      61.574224
Mean:     2.549727
dSquared: 27086.792889
Variance: 1.582080
Stdev:    1.257808
```

4 seconds seemed a reasonable default for use on local networks; happy to leave that at `urllib`'s default if consensus is that makes more sense.