### PR TITLE
increase default timeout

### DIFF
--- a/radiotherm/thermostat.py
+++ b/radiotherm/thermostat.py
@@ -22,7 +22,7 @@ class Thermostat(object):
     # and it's the right thing to do.
     JSON_HEADER = {'Content-Type' : 'application/json'}
 
-    def __init__(self, host, timeout=4):
+    def __init__(self, host, timeout=10):
         self.host = host
         self.timeout = timeout
 


### PR DESCRIPTION
My thermostat consistently requires 4-5s to complete the request for program_heat ('/tstat/program/heat'). Setting the timeout to 5s seems to work 100% in my limited tests. I suggest making the default timeout 2x that value.